### PR TITLE
Remove dependency on win_facts module.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,5 @@
 #Encapsulates policy and rule classes.
-#Can disable postrun_facts and control_rules. 
+#Can disable postrun_facts and control_rules.
 #"rule_key" value used to identify key name that stores firewall rules in Hiera.
 class windows_firewall (
     $profile_state = 'on',
@@ -8,31 +8,37 @@ class windows_firewall (
     $purge_rules = false,
     $rule_key = 'windows_networks',
 ){
-    case $::operatingsystemversion {
-        /(Windows Server 2008|Windows Server 2012)/: {
-            $firewall_name = 'MpsSvc'
+    if $::os['family'] == 'windows' {
+      case $::os['release']['major'] {
+          /(2008|2008 R2|2012|2012 R2)/: {
+              $firewall_name = 'MpsSvc'
 
-            service { 'windows_firewall':
-                ensure => 'running',
-                name   => $firewall_name,
-                enable => true,
-            }->
-            class { 'windows_firewall::profile':
-                profile_state => $profile_state,
-            }->
-            class { 'windows_firewall::policy':
-                in_policy  => $in_policy,
-                out_policy => $out_policy,
-            }->
-            class { 'windows_firewall::rule':
-                rule_key  => $rule_key,
-            }->
-            resources { 'firewall_rule':
-                purge => $purge_rules,
-            }
-        }
-        default: {
-            notify {"${::operatingsystemversion} not supported": }
-        }
-    }
+              service { 'windows_firewall':
+                  ensure => 'running',
+                  name   => $firewall_name,
+                  enable => true,
+              }->
+              class { 'windows_firewall::profile':
+                  profile_state => $profile_state,
+              }->
+              class { 'windows_firewall::policy':
+                  in_policy  => $in_policy,
+                  out_policy => $out_policy,
+              }->
+              class { 'windows_firewall::rule':
+                  rule_key  => $rule_key,
+              }->
+              resources { 'firewall_rule':
+                  purge => $purge_rules,
+              }
+          }
+          default: {
+              notify {"${::os['release']['major']} not supported": }
+          }
+      }
+  }
+  else
+  {
+    notify {"${::os['family']} not supported": }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,12 +33,12 @@ class windows_firewall (
               }
           }
           default: {
-              notify {"${::os['release']['major']} not supported": }
+              notify {"${::operatingsystemmajrelease} not supported": }
           }
       }
   }
   else
   {
-    notify {"${::os['family']} not supported": }
+    notify {"${::osfamily} not supported": }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,6 @@
   ],
   "description": "Module for managing windows firewall.",
   "dependencies": [
-    {"name":"puppetlabs/stdlib","version_requirement":"4.3.2"},
-    {"name":"liamjbennett/win_facts","version_requirement":"0.0.2"}
+    {"name":"puppetlabs/stdlib","version_requirement":"4.3.2"}
   ]
 }


### PR DESCRIPTION
I removed the dependency on the win_facts module mainly because there is a PaxHeader issue with the current tarzip in the forge. Removing the dependency seemed like the easiest option as it's usage appears redundant?