### PR TITLE
Fix escape characters in fw rule name

### DIFF
--- a/lib/puppet/provider/firewall_rule/rule.rb
+++ b/lib/puppet/provider/firewall_rule/rule.rb
@@ -5,7 +5,7 @@ class WIN32OLE
     selected = Array.new()
     self.each do |x|
       x_value = x.invoke(attr_name)
-      if x_value =~ /^#{value}$/i or x_value == value
+      if x_value =~ /^#{value.inspect}$/i or x_value == value
         selected.push(x)
       end
     end


### PR DESCRIPTION
Firewall rules with names containing \ were treated as escape
characters. The firewall_rule provider in this case fails to load the
current state of the firewall ruleset. Every puppet run, all
firewall rules are always added, leading to many duplicates.